### PR TITLE
[Fix] CSVDownload 로직 수정

### DIFF
--- a/Assets/Worker/YSH/Scripts/CSVDownload.cs
+++ b/Assets/Worker/YSH/Scripts/CSVDownload.cs
@@ -20,7 +20,7 @@ public static class CSVDownload
 
         // 다운로드가 완료된 상황
         string skillTableText = skillDataRequest.downloadHandler.text;
-        if (skillTableText == null)
+        if (skillTableText == string.Empty)
         {
             Debug.LogError("Skill Data Download Error!");
             yield break;
@@ -37,7 +37,7 @@ public static class CSVDownload
         yield return monsterDataRequest.SendWebRequest();
 
         string monsterTableText = monsterDataRequest.downloadHandler.text;
-        if (monsterTableText == null)
+        if (monsterTableText == string.Empty)
         {
             Debug.LogError("Monster Data Download Error!");
             yield break;
@@ -54,7 +54,7 @@ public static class CSVDownload
         yield return dropDataRequest.SendWebRequest();
 
         string dropTableText = dropDataRequest.downloadHandler.text;
-        if (dropTableText == null)
+        if (dropTableText == string.Empty)
         {
             Debug.LogError("Drop Data Download Error!");
             yield break;

--- a/Assets/Worker/YSH/Scripts/DataManager.cs
+++ b/Assets/Worker/YSH/Scripts/DataManager.cs
@@ -78,17 +78,17 @@ public class DataManager : Singleton<DataManager>
         string skillText = skillDataEnumerator.Current as string;
         if (skillText == null)
         {
-            yield return null;
             yield break;
         }
 
+        // UnityWebRequest를 통해 다운로드 한 내용을 전달하여 파싱한다.
         if (CSVParser.GetDataStringWithWeb(skillText, out string[] lines) == false)
         {
             Debug.Log("Skill Data Parse Error!");
-            yield return null;
             yield break;
         }
 
+        // 파싱된 내용을 Data 클래스 인스턴스에 할당하고 딕셔너리에 저장한다.
         for (int line = 1; line < lines.Length; line++)
         {
             SkillData skillData = new SkillData();
@@ -109,14 +109,12 @@ public class DataManager : Singleton<DataManager>
         string monsterText = monsterDataEnumerator.Current as string;
         if (monsterText == null)
         {
-            yield return null;
             yield break;
         }
 
         if (CSVParser.GetDataStringWithWeb(monsterText, out string[] lines) == false)
         {
             Debug.Log("Monster Data Parse Error!");
-            yield return null;
             yield break;
         }
 
@@ -140,14 +138,12 @@ public class DataManager : Singleton<DataManager>
         string dropText = dropDataEnumerator.Current as string;
         if (dropText == null)
         {
-            yield return null;
             yield break;
         }
 
         if (CSVParser.GetDataStringWithWeb(dropText, out string[] lines) == false)
         {
             Debug.Log("Drop Data Parse Error!");
-            yield return null;
             yield break;
         }
 


### PR DESCRIPTION
- DataDownloadRoutine에서 데이터 로딩이 실패한 경우에도 null은 아니기 때문에 string.Empty와 비교하도록 수정
- DataManager의 LoadData에서 불필요한 yield return null 제거